### PR TITLE
Added hmin to conisi model

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -234,7 +234,7 @@ COVIDmodel <- function(parm_table, pop_size, num_days){
       model,
       c(100, 1000, 10000),
       #These are not actually used, just passing it because lsoda wants a vector
-      hmin = 1e-5, atol = 1e-3
+      hmin = 1e-12, atol = 1e-6
     )
   )
   return(model_output)

--- a/R/model.R
+++ b/R/model.R
@@ -234,7 +234,7 @@ COVIDmodel <- function(parm_table, pop_size, num_days){
       model,
       c(100, 1000, 10000),
       #These are not actually used, just passing it because lsoda wants a vector
-      hmin = 1e-6
+      hmin = 1e-5, atol = 1e-3
     )
   )
   return(model_output)

--- a/R/model.R
+++ b/R/model.R
@@ -234,7 +234,7 @@ COVIDmodel <- function(parm_table, pop_size, num_days){
       model,
       c(100, 1000, 10000),
       #These are not actually used, just passing it because lsoda wants a vector
-      hmin = 1e-2
+      hmin = 1e-6
     )
   )
   return(model_output)

--- a/R/model.R
+++ b/R/model.R
@@ -232,10 +232,11 @@ COVIDmodel <- function(parm_table, pop_size, num_days){
       y,
       tspan,
       model,
-      c(100, 1000, 10000) #These are not actually used, just passing it because lsoda wants a vector
+      c(100, 1000, 10000),
+      #These are not actually used, just passing it because lsoda wants a vector
+      hmin = 1e-2
     )
   )
-
   return(model_output)
 }
 

--- a/R/rmse.R
+++ b/R/rmse.R
@@ -1,6 +1,7 @@
 
 se <- function(actual, predicted){
-  return((actual - predicted) ^ 2)
+  min_length = min(length(actual), length(predicted))
+  return((actual[1:min_length] - predicted[1:min_length]) ^ 2)
 }
 
 mse <- function(actual, predicted, weights = rep(1, length(actual))){


### PR DESCRIPTION
Set hmin to 1e-5 and atol to 1e-3 in LSoda. 
1e-3 and smaller works in standard_script_example, for monthly fitter 1e-6 and smaller, generates no warnings.
In general, the results do not seem to change with larger values. 
Changing atol to 1e-3 allows us to use 1e-5 instead of 1e-6. Results do not vary,